### PR TITLE
Don't assume a user's primary group name is the same as the username

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,8 +27,8 @@
   file:
     path: "{{ os_shade_venv | dirname }}"
     state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
+    owner: "{{ ansible_user_uid }}"
+    group: "{{ ansible_user_gid }}"
   become: True
   when:
     - os_shade_venv != None


### PR DESCRIPTION
In some environments a user's primary group isn't the same as their username, so this change introduces the `ansible_user_gid` fact when specifying permissions.